### PR TITLE
Remove interface INetworkInfo and Change tests accordingly

### DIFF
--- a/lib/core/network/network_info.dart
+++ b/lib/core/network/network_info.dart
@@ -1,17 +1,11 @@
 import 'package:data_connection_checker/data_connection_checker.dart';
 import 'package:injectable/injectable.dart';
 
-abstract class INetworkInfo {
-  Future<bool> get isConnected;
-}
-
 @lazySingleton
-@RegisterAs(INetworkInfo)
-class NetworkInfo implements INetworkInfo {
+class NetworkInfo {
   const NetworkInfo(this.connectionChecker);
 
   final DataConnectionChecker connectionChecker;
 
-  @override
   Future<bool> get isConnected => connectionChecker.hasConnection;
 }

--- a/lib/features/home/data/repositories/home_repository.dart
+++ b/lib/features/home/data/repositories/home_repository.dart
@@ -21,7 +21,7 @@ class HomeRepository implements IHomeRepository {
       this._networkInfo, this._remoteDataSource, this._localDataSource);
 
   final IHomeLocalDataSource _localDataSource;
-  final INetworkInfo _networkInfo;
+  final NetworkInfo _networkInfo;
   final IHomeRemoteDataSource _remoteDataSource;
 
   @override

--- a/test/features/home/data/repositories/home_repository_test.dart
+++ b/test/features/home/data/repositories/home_repository_test.dart
@@ -16,7 +16,7 @@ class MockHomeRemoteDataSource extends Mock implements IHomeRemoteDataSource {}
 
 class MockHomeLocalDataSource extends Mock implements IHomeLocalDataSource {}
 
-class MockNetworkInfo extends Mock implements INetworkInfo {}
+class MockNetworkInfo extends Mock implements NetworkInfo {}
 
 void main() {
   MockHomeLocalDataSource mockLocalDataSource;


### PR DESCRIPTION
**Refactor NetworkInfo**

Removed Abstract class INetworkInfo from network_info.dart and made suitable changes in home_repository.dart and home_repository_test.dart.

Fixes #14 